### PR TITLE
fix: avoid client side bundle to include tiny fe server code

### DIFF
--- a/components/ExampleTinyFrontend/ExampleTinyFrontend.server.tsx
+++ b/components/ExampleTinyFrontend/ExampleTinyFrontend.server.tsx
@@ -1,14 +1,12 @@
-import {
-  ExampleTinyFrontendType,
-  loadExampleTinyFrontendServer,
-} from "@tiny-frontend/example-tiny-frontend-contract";
+import { loadExampleTinyFrontendServer } from "@tiny-frontend/example-tiny-frontend-contract";
 
-export let ExampleTinyFrontendServer: ExampleTinyFrontendType;
-
-export const ensureExampleTinyFrontendLoadedServer = async () => {
-  const tinyFrontendServerResponse = await loadExampleTinyFrontendServer(
-    "https://tiny-frontent-api-cloudlare-example.gnomesgames.workers.dev/api"
-  );
-  ExampleTinyFrontendServer = tinyFrontendServerResponse.tinyFrontend;
-  return tinyFrontendServerResponse;
+export const loadTinyFrontendServer = async () => {
+  const { tinyFrontend, tinyFrontendSsrConfig } =
+    await loadExampleTinyFrontendServer(
+      "https://tiny-frontent-api-cloudlare-example.gnomesgames.workers.dev/api"
+    );
+  return {
+    ExampleTinyFrontendServer: tinyFrontend,
+    tinyFrontendSsrConfig,
+  };
 };

--- a/components/ExampleTinyFrontend/ExampleTinyFrontendServerContext.ts
+++ b/components/ExampleTinyFrontend/ExampleTinyFrontendServerContext.ts
@@ -1,0 +1,9 @@
+import { ExampleTinyFrontendType } from "@tiny-frontend/example-tiny-frontend-contract";
+import React from "react";
+
+interface ContextType {
+  ExampleTinyFrontendServer?: ExampleTinyFrontendType;
+}
+
+export const ExampleTinyFrontendServerContext =
+  React.createContext<ContextType>({});

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { TinyFrontendSsrConfig } from "@tiny-frontend/client";
+import { ExampleTinyFrontendType } from "@tiny-frontend/example-tiny-frontend-contract";
 import { TinyHead } from "@tiny-frontend/tiny-client-react";
 import Document, {
   DocumentContext,
@@ -11,21 +12,28 @@ import Document, {
 import React from "react";
 import { ServerStyleSheet } from "styled-components";
 
-import { ensureExampleTinyFrontendLoadedServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
+import { loadTinyFrontendServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
+import { ExampleTinyFrontendServerContext } from "../components/ExampleTinyFrontend/ExampleTinyFrontendServerContext";
 
 interface CustomInitialProps extends DocumentInitialProps {
   tinyFrontendSsrConfig: TinyFrontendSsrConfig;
+  ExampleTinyFrontendServer: ExampleTinyFrontendType;
 }
 export default class LayoutDocument extends Document<CustomInitialProps> {
   render(): React.ReactElement {
-    const { tinyFrontendSsrConfig } = this.props;
+    const { tinyFrontendSsrConfig, ExampleTinyFrontendServer } = this.props;
+
     return (
       <Html lang="en">
         <Head>
           <TinyHead config={tinyFrontendSsrConfig} />
         </Head>
         <body>
-          <Main />
+          <ExampleTinyFrontendServerContext.Provider
+            value={{ ExampleTinyFrontendServer }}
+          >
+            <Main />
+          </ExampleTinyFrontendServerContext.Provider>
           <div id="main" />
           <NextScript />
         </body>
@@ -40,8 +48,8 @@ export default class LayoutDocument extends Document<CustomInitialProps> {
     const originalRenderPage = ctx.renderPage;
 
     try {
-      const { tinyFrontendSsrConfig } =
-        await ensureExampleTinyFrontendLoadedServer();
+      const { tinyFrontendSsrConfig, ExampleTinyFrontendServer } =
+        await loadTinyFrontendServer();
 
       ctx.renderPage = () =>
         originalRenderPage({
@@ -54,6 +62,7 @@ export default class LayoutDocument extends Document<CustomInitialProps> {
       return {
         ...initialProps,
         tinyFrontendSsrConfig,
+        ExampleTinyFrontendServer,
         styles: (
           <>
             {initialProps.styles}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,16 @@
 import type { NextPage } from "next";
+import { useContext } from "react";
 
 import { ExampleTinyFrontendClient } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.client";
-import { ExampleTinyFrontendServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
+import { ExampleTinyFrontendServerContext } from "../components/ExampleTinyFrontend/ExampleTinyFrontendServerContext";
 import styles from "../styles/Home.module.css";
 
-interface HomeProps {
-  __html: string;
-}
-const Home: NextPage<HomeProps> = () => {
+const Home: NextPage = () => {
+  const { ExampleTinyFrontendServer } = useContext(
+    ExampleTinyFrontendServerContext
+  );
   const ExampleTinyFrontend =
-    ExampleTinyFrontendServer || ExampleTinyFrontendClient;
+    ExampleTinyFrontendServer ?? ExampleTinyFrontendClient;
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
Next build system doesn't seem to be able to treeshake the server loader function from Tiny Client and it ends up in the client bundle:

<img width="968" alt="image" src="https://user-images.githubusercontent.com/4410247/158017499-98a67aaa-0e95-409c-965d-45024a5c144c.png">

This change uses context on the server instead of a top level variable to pass the server component down. This let the `index` page access the component without having to import the `.server.ts` file.

After this change, the server side function for Tiny Client is no longer included in the client side JS bundle:
<img width="760" alt="image" src="https://user-images.githubusercontent.com/4410247/158017521-134c4cf0-8712-4772-a3fb-c8062ac5486b.png">
