### PR TITLE
POC - React context as MFE store

### DIFF
--- a/components/ExampleTinyFrontend/ExampleTinyFrontend.tsx
+++ b/components/ExampleTinyFrontend/ExampleTinyFrontend.tsx
@@ -1,0 +1,16 @@
+import { ExampleTinyFrontendType } from "@tiny-frontend/example-tiny-frontend-contract";
+
+import { MicrofrontendsContext } from "../../context/microfrontends";
+import { ExampleTinyFrontendClient } from "./ExampleTinyFrontend.client";
+
+const ExampleTinyFrontend: ExampleTinyFrontendType = (props) => (
+  <MicrofrontendsContext.Consumer>
+    {({ ExampleTinyFrontendServer }) => {
+      const ExampleTinyFrontend =
+        ExampleTinyFrontendServer ?? ExampleTinyFrontendClient;
+      return <ExampleTinyFrontend {...props} />;
+    }}
+  </MicrofrontendsContext.Consumer>
+);
+
+export default ExampleTinyFrontend;

--- a/components/ExampleTinyFrontend/ExampleTinyFrontend.tsx
+++ b/components/ExampleTinyFrontend/ExampleTinyFrontend.tsx
@@ -6,6 +6,7 @@ import { ExampleTinyFrontendClient } from "./ExampleTinyFrontend.client";
 const ExampleTinyFrontend: ExampleTinyFrontendType = (props) => (
   <MicrofrontendsContext.Consumer>
     {({ ExampleTinyFrontendServer }) => {
+      console.log({ ExampleTinyFrontendServer, ExampleTinyFrontendClient });
       const ExampleTinyFrontend =
         ExampleTinyFrontendServer ?? ExampleTinyFrontendClient;
       return <ExampleTinyFrontend {...props} />;

--- a/components/ExampleTinyFrontend/TinyFrontendServerStorage.ts
+++ b/components/ExampleTinyFrontend/TinyFrontendServerStorage.ts
@@ -1,7 +1,0 @@
-import { ExampleTinyFrontendType } from "@tiny-frontend/example-tiny-frontend-contract";
-
-interface ServerStorageType {
-  Component?: ExampleTinyFrontendType;
-}
-
-export const TinyFrontendServerStorage: ServerStorageType = {};

--- a/components/ExampleTinyFrontend/index.tsx
+++ b/components/ExampleTinyFrontend/index.tsx
@@ -1,0 +1,3 @@
+import ExampleTinyFrontend from "./ExampleTinyFrontend";
+
+export default ExampleTinyFrontend;

--- a/components/styled-anchor.tsx
+++ b/components/styled-anchor.tsx
@@ -1,15 +1,31 @@
-import React from "react";
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import Link, { LinkProps } from "next/link";
+import React, { forwardRef } from "react";
 
-export const StyledAnchor: React.FC<JSX.IntrinsicElements["a"]> = ({
-  children,
-  ...props
-}) => (
-  <a
-    {...props}
-    className={`border-b-2 border-b-primary-base hover:border-b-primary-light transition-all ${
-      props.className ?? ""
-    }`}
-  >
-    {children}
-  </a>
+type EnhancedLinkProps = {
+  children: React.ReactNode | React.ReactNode[];
+  className?: string;
+  target?: string;
+  rel?: string;
+} & LinkProps;
+
+// eslint-disable-next-line react/display-name
+export const StyledAnchor = forwardRef<HTMLAnchorElement, EnhancedLinkProps>(
+  (
+    { as, passHref, prefetch, href, children, className, target, ...rest },
+    ref
+  ) => (
+    <Link href={href} as={as} passHref={passHref} prefetch={prefetch}>
+      <a
+        {...rest}
+        target={target}
+        ref={ref}
+        className={`border-b-2 border-b-primary-base hover:border-b-primary-light transition-all ${
+          className ?? ""
+        }`}
+      >
+        {children}
+      </a>
+    </Link>
+  )
 );

--- a/context/microfrontends.tsx
+++ b/context/microfrontends.tsx
@@ -1,0 +1,35 @@
+import { ExampleTinyFrontendType } from "@tiny-frontend/example-tiny-frontend-contract";
+import React, { PropsWithChildren, ReactNode } from "react";
+
+export interface MicroFrontendStore {
+  ExampleTinyFrontendServer: ExampleTinyFrontendType;
+}
+
+export const initialState: MicroFrontendStore = {
+  ExampleTinyFrontendServer: () => null,
+};
+
+const MicrofrontendsContext =
+  React.createContext<MicroFrontendStore>(initialState);
+
+const MicrofrontendsContextProvider: React.FC<PropsWithChildren<any>> = ({
+  value,
+  children,
+}: {
+  value: MicroFrontendStore;
+  children: ReactNode;
+}) => {
+  return (
+    <MicrofrontendsContext.Provider value={value}>
+      {children}
+    </MicrofrontendsContext.Provider>
+  );
+};
+
+const MicrofrontendsContextConsumer = MicrofrontendsContext.Consumer;
+
+export {
+  MicrofrontendsContext,
+  MicrofrontendsContextConsumer,
+  MicrofrontendsContextProvider,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@cazoo/eslint-plugin-eslint": "^1.0.2",
-        "@tiny-frontend/client": "^0.0.8",
+        "@tiny-frontend/client": "^0.0.9",
         "@types/node": "17.0.18",
         "@types/react": "17.0.39",
         "@types/react-dom": "^17.0.11",
@@ -722,10 +722,9 @@
       }
     },
     "node_modules/@tiny-frontend/client": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.8.tgz",
-      "integrity": "sha512-r+6ctr52KcJd5+YzP7QAgQ6Kaeyvr/uqoXp2VrjaiCFN0KDTmgjHsl+Psxh6k426O7DhbUJnJTnGLswy+rD5mQ==",
-      "dev": true,
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.9.tgz",
+      "integrity": "sha512-PklL4HeKZN+zDN8lBcnxJsYjNrxP/+hCPRrwQijekMm8Qkm73jLfGJ4IY087XTpsgPkwL5LOGbgC4wwUbp3FPQ==",
       "dependencies": {
         "@ungap/global-this": "^0.4.4"
       }
@@ -739,14 +738,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.2"
-      }
-    },
-    "node_modules/@tiny-frontend/example-tiny-frontend-contract/node_modules/@tiny-frontend/client": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.9.tgz",
-      "integrity": "sha512-PklL4HeKZN+zDN8lBcnxJsYjNrxP/+hCPRrwQijekMm8Qkm73jLfGJ4IY087XTpsgPkwL5LOGbgC4wwUbp3FPQ==",
-      "dependencies": {
-        "@ungap/global-this": "^0.4.4"
       }
     },
     "node_modules/@tiny-frontend/tiny-client-react": {
@@ -4470,10 +4461,9 @@
       }
     },
     "@tiny-frontend/client": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.8.tgz",
-      "integrity": "sha512-r+6ctr52KcJd5+YzP7QAgQ6Kaeyvr/uqoXp2VrjaiCFN0KDTmgjHsl+Psxh6k426O7DhbUJnJTnGLswy+rD5mQ==",
-      "dev": true,
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.9.tgz",
+      "integrity": "sha512-PklL4HeKZN+zDN8lBcnxJsYjNrxP/+hCPRrwQijekMm8Qkm73jLfGJ4IY087XTpsgPkwL5LOGbgC4wwUbp3FPQ==",
       "requires": {
         "@ungap/global-this": "^0.4.4"
       }
@@ -4484,16 +4474,6 @@
       "integrity": "sha512-yWerIYyMycPuNzpW76NBaTeELrrydHXnTIcYMlp7lURbM4yxj9I7W2B/N09SsY2jsNfNh6ZcH7alz2lK/Hi06Q==",
       "requires": {
         "@tiny-frontend/client": "^0.0.9"
-      },
-      "dependencies": {
-        "@tiny-frontend/client": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/@tiny-frontend/client/-/client-0.0.9.tgz",
-          "integrity": "sha512-PklL4HeKZN+zDN8lBcnxJsYjNrxP/+hCPRrwQijekMm8Qkm73jLfGJ4IY087XTpsgPkwL5LOGbgC4wwUbp3FPQ==",
-          "requires": {
-            "@ungap/global-this": "^0.4.4"
-          }
-        }
       }
     },
     "@tiny-frontend/tiny-client-react": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "styled-components": "^5.3.3"
   },
   "devDependencies": {
-    "@tiny-frontend/client": "^0.0.8",
     "@cazoo/eslint-plugin-eslint": "^1.0.2",
+    "@tiny-frontend/client": "^0.0.9",
     "@types/node": "17.0.18",
     "@types/react": "17.0.39",
     "@types/react-dom": "^17.0.11",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,13 +2,27 @@ import "../styles/globals.css";
 
 import type { AppProps } from "next/app";
 
+import { loadTinyFrontendServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
+import { MicrofrontendsContextProvider } from "../context/microfrontends";
+
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  const { microfrontends, ...props } = pageProps;
+  return (
+    <MicrofrontendsContextProvider value={microfrontends}>
+      <Component {...props} />
+    </MicrofrontendsContextProvider>
+  );
 }
 
-MyApp.getInitialProps = () => {
-  // Force Next.js to SSR pages as we want it to re-fetch our tiny frontends each time.
-  return {};
+MyApp.getInitialProps = async (): Promise<{
+  pageProps: Record<string, unknown>;
+}> => {
+  const { ExampleTinyFrontendServer } = await loadTinyFrontendServer();
+
+  const microfrontends = { ExampleTinyFrontendServer };
+  const pageProps = { microfrontends };
+
+  return { pageProps };
 };
 
 export default MyApp;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,27 +2,8 @@ import "../styles/globals.css";
 
 import type { AppProps } from "next/app";
 
-import { loadTinyFrontendServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
-import { MicrofrontendsContextProvider } from "../context/microfrontends";
-
 function MyApp({ Component, pageProps }: AppProps) {
-  const { microfrontends, ...props } = pageProps;
-  return (
-    <MicrofrontendsContextProvider value={microfrontends}>
-      <Component {...props} />
-    </MicrofrontendsContextProvider>
-  );
+  return <Component {...pageProps} />;
 }
-
-MyApp.getInitialProps = async (): Promise<{
-  pageProps: Record<string, unknown>;
-}> => {
-  const { ExampleTinyFrontendServer } = await loadTinyFrontendServer();
-
-  const microfrontends = { ExampleTinyFrontendServer };
-  const pageProps = { microfrontends };
-
-  return { pageProps };
-};
 
 export default MyApp;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import { ServerStyleSheet } from "styled-components";
 
 import { loadTinyFrontendServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
-import { TinyFrontendServerStorage } from "../components/ExampleTinyFrontend/TinyFrontendServerStorage";
 import { StyledAnchor } from "../components/styled-anchor";
 
 interface CustomInitialProps extends DocumentInitialProps {
@@ -58,10 +57,7 @@ export default class LayoutDocument extends Document<CustomInitialProps> {
     const originalRenderPage = ctx.renderPage;
 
     try {
-      const { tinyFrontendSsrConfig, ExampleTinyFrontendServer } =
-        await loadTinyFrontendServer();
-
-      TinyFrontendServerStorage.Component = ExampleTinyFrontendServer;
+      const { tinyFrontendSsrConfig } = await loadTinyFrontendServer();
 
       ctx.renderPage = () =>
         originalRenderPage({

--- a/pages/client-side-only.tsx
+++ b/pages/client-side-only.tsx
@@ -1,6 +1,6 @@
 import {
   ExampleTinyFrontendType,
-  loadExampleTinyFrontendClient,
+  loadExampleTinyFrontendClient
 } from "@tiny-frontend/example-tiny-frontend-contract";
 import type { NextPage } from "next";
 import Link from "next/link";
@@ -49,9 +49,9 @@ const Home: NextPage = () => {
         You have pressed the button inside the tiny frontend{" "}
         <strong>{counter} times</strong>.
       </p>
-      <Link href="/" passHref>
-        <StyledAnchor className="inline-block">← Back to index</StyledAnchor>
-      </Link>
+      <StyledAnchor href="/" className="inline-block">
+        ← Back to index
+      </StyledAnchor>
     </div>
   );
 };

--- a/pages/client-side-only.tsx
+++ b/pages/client-side-only.tsx
@@ -3,7 +3,6 @@ import {
   loadExampleTinyFrontendClient
 } from "@tiny-frontend/example-tiny-frontend-contract";
 import type { NextPage } from "next";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { DescriptionBlock } from "../components/description-block";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from "next";
-import Link from "next/link";
 
 import { DescriptionBlock } from "../components/description-block";
 import { StyledAnchor } from "../components/styled-anchor";
@@ -20,6 +19,7 @@ const Index: NextPage = () => {
           app that can load a{" "}
           <StyledAnchor
             href="https://tiny-frontend.github.io/"
+            target="_blank"
             rel="noreferrer"
           >
             tiny frontend

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,6 @@ const Index: NextPage = () => {
           app that can load a{" "}
           <StyledAnchor
             href="https://tiny-frontend.github.io/"
-            target="_blank"
             rel="noreferrer"
           >
             tiny frontend
@@ -40,22 +39,18 @@ const Index: NextPage = () => {
         </p>
         <ul className="flex flex-col gap-2 md:flex-row md:gap-6 justify-center">
           <li>
-            <Link href="/ssr" passHref>
-              <StyledAnchor>
-                A tiny frontend loaded{" "}
-                <strong className="text-primary-base">
-                  on SSR and client side
-                </strong>
-              </StyledAnchor>
-            </Link>
+            <StyledAnchor href="/ssr">
+              A tiny frontend loaded{" "}
+              <strong className="text-primary-base">
+                on SSR and client side
+              </strong>
+            </StyledAnchor>
           </li>
           <li>
-            <Link href="/client-side-only" passHref>
-              <StyledAnchor className="border-b-2">
-                A tiny frontend loaded{" "}
-                <strong className="text-primary-base">client side only</strong>
-              </StyledAnchor>
-            </Link>
+            <StyledAnchor href="/client-side-only" className="border-b-2">
+              A tiny frontend loaded{" "}
+              <strong className="text-primary-base">client side only</strong>
+            </StyledAnchor>
           </li>
         </ul>
       </div>

--- a/pages/ssr.tsx
+++ b/pages/ssr.tsx
@@ -3,14 +3,10 @@ import Link from "next/link";
 import { useState } from "react";
 
 import { DescriptionBlock } from "../components/description-block";
-import { ExampleTinyFrontendClient } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.client";
-import { TinyFrontendServerStorage } from "../components/ExampleTinyFrontend/TinyFrontendServerStorage";
+import ExampleTinyFrontend from "../components/ExampleTinyFrontend";
 import { StyledAnchor } from "../components/styled-anchor";
 
 const Home: NextPage = () => {
-  const ExampleTinyFrontend =
-    TinyFrontendServerStorage.Component ?? ExampleTinyFrontendClient;
-
   const [counter, setCounter] = useState(0);
 
   return (

--- a/pages/ssr.tsx
+++ b/pages/ssr.tsx
@@ -26,9 +26,9 @@ const Home: NextPage = () => {
         You have pressed the button inside the tiny frontend{" "}
         <strong>{counter} times</strong>.
       </p>
-      <Link href="/" passHref>
-        <StyledAnchor className="inline-block">← Back to index</StyledAnchor>
-      </Link>
+      <StyledAnchor href="/" className="inline-block">
+        ← Back to index
+      </StyledAnchor>
     </div>
   );
 };

--- a/pages/ssr.tsx
+++ b/pages/ssr.tsx
@@ -1,35 +1,61 @@
-import type { NextPage } from "next";
-import Link from "next/link";
+import type { GetServerSideProps, NextPage } from "next";
 import { useState } from "react";
+import serialize from "serialize-javascript";
 
 import { DescriptionBlock } from "../components/description-block";
 import ExampleTinyFrontend from "../components/ExampleTinyFrontend";
+import { loadTinyFrontendServer } from "../components/ExampleTinyFrontend/ExampleTinyFrontend.server";
 import { StyledAnchor } from "../components/styled-anchor";
+import { MicrofrontendsProvider } from "../context/microfrontends";
 
-const Home: NextPage = () => {
+const Home: NextPage = ({ microfrontends }: any) => {
   const [counter, setCounter] = useState(0);
 
+  const { ExampleTinyFrontendServer } = microfrontends;
+
+  const store = {
+    ExampleTinyFrontendServer
+  };
+
   return (
-    <div className="space-y-4 md:space-y-6">
-      <DescriptionBlock>
+    <MicrofrontendsProvider value={store}>
+      <div className="space-y-4 md:space-y-6">
+        <DescriptionBlock>
+          <p>
+            Below, inside the dashed box, is a tiny frontend loaded dynamically{" "}
+            <strong className="text-primary-base">
+              on SSR and client side
+            </strong>
+            .
+          </p>
+          <p>
+            Try disabling JavaScript, and marvel as the tiny frontend still
+            displays on page load ✨ !
+          </p>
+        </DescriptionBlock>
+        <ExampleTinyFrontend name="SSR Next.js" onCounterChange={setCounter} />
         <p>
-          Below, inside the dashed box, is a tiny frontend loaded dynamically{" "}
-          <strong className="text-primary-base">on SSR and client side</strong>.
+          You have pressed the button inside the tiny frontend{" "}
+          <strong>{counter} times</strong>.
         </p>
-        <p>
-          Try disabling JavaScript, and marvel as the tiny frontend still
-          displays on page load ✨ !
-        </p>
-      </DescriptionBlock>
-      <ExampleTinyFrontend name="Next.js" onCounterChange={setCounter} />
-      <p>
-        You have pressed the button inside the tiny frontend{" "}
-        <strong>{counter} times</strong>.
-      </p>
-      <StyledAnchor href="/" className="inline-block">
-        ← Back to index
-      </StyledAnchor>
-    </div>
+        <StyledAnchor href="/" className="inline-block">
+          ← Back to index
+        </StyledAnchor>
+      </div>
+    </MicrofrontendsProvider>
   );
 };
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const { ExampleTinyFrontendServer } = await loadTinyFrontendServer();
+
+  return {
+    props: {
+      microfrontends: {
+        ExampleTinyFrontendServer: ExampleTinyFrontendServer.toString()
+      }
+    }
+  };
+};
+
 export default Home;


### PR DESCRIPTION
Before, we were relying on the existence of a ServerStorage property to render from SSR or CSR.

Now, we want to keep all the SSR references stored in a context, so that we can reuse them later.

The problem is I'm not getting the "eval"/new Function part working for the bundle definition I'm saving.
